### PR TITLE
Update intro.md, qbcompele.sh, number_parser.py

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@
 
 ##### JAV刮削
 
-配置可参考 [Movie_Data_Capture wiki](https://github.com/yoshiko2/Movie_Data_Capture/wiki)<br>
+配置可参考 [Movie_Data_Capture wiki](https://githubfast.com/yoshiko2/Movie_Data_Capture/wiki)<br>
 ~~使用mdc的刮削库，参数略有修改~~
 
 刮削默认跳过带有忽略或已完成标记的影片。
@@ -78,7 +78,8 @@ http://192.168.1.233:8096/emby/Items/3227ce1e069754c594af25ea66d69fc7/Refresh?Re
 - ~~后续可能修改策略,直接扫描下载目录,不需要配置这些~~
 __注:__ 
 - 默认请求 __127.0.0.1__ ,需根据实际情况更改
-- tr可参考[配置完成脚本](https://github.com/ronggang/transmission-web-control/wiki/About-script-torrent-done-filename)
+- tr可参考[配置完成脚本](https://githubfast.com/ronggang/transmission-web-control/wiki/About-script-torrent-done-filename)
+- 如果docker的挂载路径与qbit挂载路径不同名的话，需要用以下命令a="%F"&& sh qbcomplete.sh ${a/bit挂载路径/ikros挂载路径}，tr同理
 
 ### 其他
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -79,7 +79,7 @@ http://192.168.1.233:8096/emby/Items/3227ce1e069754c594af25ea66d69fc7/Refresh?Re
 __注:__ 
 - 默认请求 __127.0.0.1__ ,需根据实际情况更改
 - tr可参考[配置完成脚本](https://githubfast.com/ronggang/transmission-web-control/wiki/About-script-torrent-done-filename)
-- 如果docker的挂载路径与qbit挂载路径不同名的话，需要用以下命令a="%F"&& sh qbcomplete.sh ${a/bit挂载路径/ikros挂载路径}，tr同理
+- 如果docker的挂载路径与qbit挂载路径不同名的话，需要用以下命令`a="%F"&& sh qbcomplete.sh ${a/bit挂载路径/ikros挂载路径}`，tr同理
 
 ### 其他
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@
 
 ##### JAV刮削
 
-配置可参考 [Movie_Data_Capture wiki](https://githubfast.com/yoshiko2/Movie_Data_Capture/wiki)<br>
+配置可参考 [Movie_Data_Capture wiki](https://github.com/yoshiko2/Movie_Data_Capture/wiki)<br>
 ~~使用mdc的刮削库，参数略有修改~~
 
 刮削默认跳过带有忽略或已完成标记的影片。

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -78,7 +78,7 @@ http://192.168.1.233:8096/emby/Items/3227ce1e069754c594af25ea66d69fc7/Refresh?Re
 - ~~后续可能修改策略,直接扫描下载目录,不需要配置这些~~
 __注:__ 
 - 默认请求 __127.0.0.1__ ,需根据实际情况更改
-- tr可参考[配置完成脚本](https://githubfast.com/ronggang/transmission-web-control/wiki/About-script-torrent-done-filename)
+- tr可参考[配置完成脚本](https://github.com/ronggang/transmission-web-control/wiki/About-script-torrent-done-filename)
 - 如果docker的挂载路径与qbit挂载路径不同名的话，需要用以下命令`a="%F"&& sh qbcomplete.sh ${a/bit挂载路径/ikros挂载路径}`，tr同理
 
 ### 其他

--- a/scripts/qbcomplete.sh
+++ b/scripts/qbcomplete.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # qbcomplete.sh "%F"
+# 如果docker的挂载路径与qbit挂载路径不同名的话，需要用以下命令a="%F"&& sh qbcomplete.sh ${a/qbit挂载路径/ikros挂载路径}
 
 QB_DOWNLOADS="${1}"
 curl -XPOST http://127.0.0.1:12346/api/client -H 'Content-Type: application/json' \

--- a/src/utils/number_parser.py
+++ b/src/utils/number_parser.py
@@ -30,7 +30,7 @@ class FileNumInfo():
         if '流出' in filepath or '-leak' in filepath or '_leak' in filepath \
                 or '-uncensored' in filepath or '_uncensored' in filepath:
             self.leak_tag = True
-        if '破解' in filepath or '-hack' in filepath or '_hack' in filepath or '-quitu' in filepath or '-u' in filepath or '_u' in filepath:
+        if '破解' in filepath or '-hack' in filepath or '_hack' in filepath or '-u' in filepath or '_u' in filepath:
             self.hack_tag = True
 
         cnlist = ['中文', '字幕', '-c.', '_c.', '_c_', '-c-', '-uc', '_uc']
@@ -167,7 +167,7 @@ G_TAKE_NUM_RULES = {
     'heyzo': lambda x: 'HEYZO-' + re.findall(r'heyzo[^\d]*(\d{4})', x, re.I)[0],
     'mdbk': lambda x: str(re.search(r'mdbk(-|_)(\d{4})', x, re.I).group()),
     'mdtm': lambda x: str(re.search(r'mdtm(-|_)(\d{4})', x, re.I).group()),
-    r'([A-Za-z]{2,4}\-?\d{3})': lambda x: str(re.search(r'([A-Za-z]{2,4}\-?\d{3})', x, re.I).group()), # 保底用
+    r'([A-Za-z]{2,6}\-?\d{3})': lambda x: str(re.search(r'([A-Za-z]{2,6}\-?\d{3})', x, re.I).group()), # 保底用
 }
 
 


### PR DESCRIPTION
增加文档：如果docker的挂载路径与qbit挂载路径不同名的话，需要用以下命令`a="%F"&& sh qbcomplete.sh ${a/bit挂载路径/ikros挂载路径}`，tr同理
修正 `get_number_by_dict`方法保底用的正则表达式，使之支持英文字母2-6范围的番号